### PR TITLE
Remove alpha label from context parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ console.log(await translator.translateText('How are you?', null, 'de', { formali
     containing the glossary ID, or a `GlossaryInfo` as returned by
     `getGlossary()`.
 -   `context`: specifies additional context to influence translations, that is not
-    translated itself. Note this is an **alpha feature**: it may be deprecated at
-    any time, or incur charges if it becomes generally available.
+    translated itself. Characters in the `context` parameter are not counted toward billing.
     See the [API documentation][api-docs-context-param] for more information and
     example usage.
 -   `tagHandling`: type of tags to parse before translation, options are `'html'`

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,8 +131,8 @@ export interface TranslateTextOptions {
     outlineDetection?: boolean;
 
     /** Specifies additional context to influence translations, that is not
-     * translated itself. Note this is an **alpha feature**: it may be deprecated at
-     * any time, or incur charges if it becomes generally available.
+     * translated itself. Characters in the `context` parameter are not counted
+     * toward billing.
      * See the API documentation for more information and example usage. */
     context?: string;
 


### PR DESCRIPTION
The `context` parameter is no longer an alpha feature and is generally available. This PR updates the README to reflect this change.